### PR TITLE
 Fix help file for password grant referesh_token curl sample  (#42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express-session": "1.15.6",
     "highlight.js": "9.3.0",
     "jade": "1.11.0",
-    "jquery": "3.3.1",
+    "jquery": "3.4.1",
     "jsgrid": "1.5.3",
     "marked": "0.5.2",
     "morgan": "1.9.1",

--- a/views/help/oauth2_password_grant.jade
+++ b/views/help/oauth2_password_grant.jade
@@ -109,13 +109,13 @@ block help_content
     as before. Using curl syntax, the call will look like this (for confidential clients):
 
   pre.
-    curl -X POST -H 'Content-Type: application/json' -d '{"grant_type=refresh_token","client_id":"<b style="color:#0a0">(your client id)</b>","client_secret":"<b style="color:#0a0">(your client secret)</b>","refresh_token":"<b style="color:#0a0">(refresh token)</b>"}' #{authUrl}<b style="color:#0a0">(auth method id)</b>/api/<b style="color:#0a0">(api id)</b>/token
+    curl -X POST -H 'Content-Type: application/json' -d '{"grant_type":"refresh_token","client_id":"<b style="color:#0a0">(your client id)</b>","client_secret":"<b style="color:#0a0">(your client secret)</b>","refresh_token":"<b style="color:#0a0">(refresh token)</b>"}' #{authUrl}<b style="color:#0a0">(auth method id)</b>/api/<b style="color:#0a0">(api id)</b>/token
 
   p.
     As above, public clients (non-confidential clients) <b>must not</b> present their client secret when refreshing the token:
 
   pre.
-    curl -X POST -H 'Content-Type: application/json' -d '{"grant_type=refresh_token","client_id":"<b style="color:#0a0">(your client id)</b>","refresh_token":"<b style="color:#0a0">(refresh token)</b>"}' #{authUrl}<b style="color:#0a0">(auth method id)</b>/api/<b style="color:#0a0">(api id)</b>/token
+    curl -X POST -H 'Content-Type: application/json' -d '{"grant_type":"refresh_token","client_id":"<b style="color:#0a0">(your client id)</b>","refresh_token":"<b style="color:#0a0">(refresh token)</b>"}' #{authUrl}<b style="color:#0a0">(auth method id)</b>/api/<b style="color:#0a0">(api id)</b>/token
 
   p.
     If successful, the Authorization Server will return a new access token and a new refresh token.


### PR DESCRIPTION
* Feature to allow publishing of an api without having to require any authentication.

* Don't show application related message for no-auth API

* Fixed issue https://github.com/Haufe-Lexware/wicked.haufe.io/issues/177

* Fixed https://github.com/Haufe-Lexware/wicked.haufe.io/issues/179

* Fix help file for password grant referesh_token curl sample